### PR TITLE
Upgrade to 0.0.3, correct for codeql-util breaking dense rank change.

### DIFF
--- a/cpp/src/codeql-pack.lock.yml
+++ b/cpp/src/codeql-pack.lock.yml
@@ -2,23 +2,11 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/cpp-all:
-    version: 2.1.1
-  codeql/dataflow:
-    version: 1.1.6
-  codeql/mad:
-    version: 1.0.12
-  codeql/rangeanalysis:
-    version: 1.0.12
+    version: 0.6.1
   codeql/ssa:
-    version: 1.0.12
+    version: 0.0.14
   codeql/tutorial:
-    version: 1.0.12
-  codeql/typeflow:
-    version: 1.0.12
-  codeql/typetracking:
-    version: 1.0.12
+    version: 0.0.7
   codeql/util:
-    version: 1.0.12
-  codeql/xml:
-    version: 1.0.12
+    version: 2.0.16
 compiled: false

--- a/cpp/src/qlpack.yml
+++ b/cpp/src/qlpack.yml
@@ -1,8 +1,8 @@
 name: advanced-security/qtil-cpp
 library: true
 warnOnImplicitThis: false
-version: 0.0.2
+version: 0.0.3
 license: MIT
 dependencies:
   codeql/cpp-all: '>=0.0.1 <5.0.0'
-  advanced-security/qtil: 0.0.2
+  advanced-security/qtil: 0.0.3

--- a/cpp/test/codeql-pack.lock.yml
+++ b/cpp/test/codeql-pack.lock.yml
@@ -2,23 +2,11 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/cpp-all:
-    version: 2.1.1
-  codeql/dataflow:
-    version: 1.1.6
-  codeql/mad:
-    version: 1.0.12
-  codeql/rangeanalysis:
-    version: 1.0.12
+    version: 0.6.1
   codeql/ssa:
-    version: 1.0.12
+    version: 0.0.14
   codeql/tutorial:
-    version: 1.0.12
-  codeql/typeflow:
-    version: 1.0.12
-  codeql/typetracking:
-    version: 1.0.12
+    version: 0.0.7
   codeql/util:
-    version: 1.0.12
-  codeql/xml:
-    version: 1.0.12
+    version: 2.0.16
 compiled: false

--- a/csharp/src/codeql-pack.lock.yml
+++ b/csharp/src/codeql-pack.lock.yml
@@ -2,23 +2,23 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/controlflow:
-    version: 1.0.12
+    version: 2.0.13
   codeql/csharp-all:
-    version: 3.1.1
+    version: 5.2.2
   codeql/dataflow:
-    version: 1.1.6
+    version: 2.0.13
   codeql/mad:
-    version: 1.0.12
+    version: 1.0.29
   codeql/ssa:
-    version: 1.0.12
+    version: 2.0.5
   codeql/threat-models:
-    version: 1.0.12
+    version: 1.0.29
   codeql/tutorial:
-    version: 1.0.12
+    version: 1.0.29
   codeql/typetracking:
-    version: 1.0.12
+    version: 2.0.13
   codeql/util:
-    version: 1.0.12
+    version: 2.0.16
   codeql/xml:
-    version: 1.0.12
+    version: 1.0.29
 compiled: false

--- a/csharp/src/qlpack.yml
+++ b/csharp/src/qlpack.yml
@@ -1,8 +1,8 @@
 name: advanced-security/qtil-csharp
 library: true
 warnOnImplicitThis: false
-version: 0.0.2
+version: 0.0.3
 license: MIT
 dependencies:
   codeql/csharp-all: '>=0.0.1 <6.0.0'
-  advanced-security/qtil: 0.0.2
+  advanced-security/qtil: 0.0.3

--- a/csharp/test/codeql-pack.lock.yml
+++ b/csharp/test/codeql-pack.lock.yml
@@ -2,23 +2,23 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/controlflow:
-    version: 1.0.12
+    version: 2.0.13
   codeql/csharp-all:
-    version: 3.1.1
+    version: 5.2.2
   codeql/dataflow:
-    version: 1.1.6
+    version: 2.0.13
   codeql/mad:
-    version: 1.0.12
+    version: 1.0.29
   codeql/ssa:
-    version: 1.0.12
+    version: 2.0.5
   codeql/threat-models:
-    version: 1.0.12
+    version: 1.0.29
   codeql/tutorial:
-    version: 1.0.12
+    version: 1.0.29
   codeql/typetracking:
-    version: 1.0.12
+    version: 2.0.13
   codeql/util:
-    version: 1.0.12
+    version: 2.0.16
   codeql/xml:
-    version: 1.0.12
+    version: 1.0.29
 compiled: false

--- a/go/src/codeql-pack.lock.yml
+++ b/go/src/codeql-pack.lock.yml
@@ -2,19 +2,19 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/dataflow:
-    version: 1.1.6
+    version: 2.0.13
   codeql/go-all:
-    version: 2.1.3
+    version: 4.3.2
   codeql/mad:
-    version: 1.0.12
+    version: 1.0.29
   codeql/ssa:
-    version: 1.0.12
+    version: 2.0.5
   codeql/threat-models:
-    version: 1.0.12
+    version: 1.0.29
   codeql/tutorial:
-    version: 1.0.12
+    version: 1.0.29
   codeql/typetracking:
-    version: 1.0.12
+    version: 2.0.13
   codeql/util:
-    version: 1.0.12
+    version: 2.0.16
 compiled: false

--- a/go/src/qlpack.yml
+++ b/go/src/qlpack.yml
@@ -1,8 +1,8 @@
 name: advanced-security/qtil-go
 library: true
 warnOnImplicitThis: false
-version: 0.0.2
+version: 0.0.3
 license: MIT
 dependencies:
   codeql/go-all: '>=0.0.1 <5.0.0'
-  advanced-security/qtil: 0.0.2
+  advanced-security/qtil: 0.0.3

--- a/go/test/codeql-pack.lock.yml
+++ b/go/test/codeql-pack.lock.yml
@@ -2,19 +2,19 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/dataflow:
-    version: 1.1.6
+    version: 2.0.13
   codeql/go-all:
-    version: 2.1.3
+    version: 4.3.2
   codeql/mad:
-    version: 1.0.12
+    version: 1.0.29
   codeql/ssa:
-    version: 1.0.12
+    version: 2.0.5
   codeql/threat-models:
-    version: 1.0.12
+    version: 1.0.29
   codeql/tutorial:
-    version: 1.0.12
+    version: 1.0.29
   codeql/typetracking:
-    version: 1.0.12
+    version: 2.0.13
   codeql/util:
-    version: 1.0.12
+    version: 2.0.16
 compiled: false

--- a/java/src/codeql-pack.lock.yml
+++ b/java/src/codeql-pack.lock.yml
@@ -1,28 +1,32 @@
 ---
 lockVersion: 1.0.0
 dependencies:
+  codeql/controlflow:
+    version: 2.0.13
   codeql/dataflow:
-    version: 1.1.6
+    version: 2.0.13
   codeql/java-all:
-    version: 4.2.1
+    version: 7.6.0
   codeql/mad:
-    version: 1.0.12
+    version: 1.0.29
+  codeql/quantum:
+    version: 0.0.7
   codeql/rangeanalysis:
-    version: 1.0.12
+    version: 1.0.29
   codeql/regex:
-    version: 1.0.12
+    version: 1.0.29
   codeql/ssa:
-    version: 1.0.12
+    version: 2.0.5
   codeql/threat-models:
-    version: 1.0.12
+    version: 1.0.29
   codeql/tutorial:
-    version: 1.0.12
+    version: 1.0.29
   codeql/typeflow:
-    version: 1.0.12
+    version: 1.0.29
   codeql/typetracking:
-    version: 1.0.12
+    version: 2.0.13
   codeql/util:
-    version: 1.0.12
+    version: 2.0.16
   codeql/xml:
-    version: 1.0.12
+    version: 1.0.29
 compiled: false

--- a/java/src/qlpack.yml
+++ b/java/src/qlpack.yml
@@ -1,8 +1,8 @@
 name: advanced-security/qtil-java
 library: true
 warnOnImplicitThis: false
-version: 0.0.2
+version: 0.0.3
 license: MIT
 dependencies:
   codeql/java-all: '>=0.0.1 <8.0.0'
-  advanced-security/qtil: 0.0.2
+  advanced-security/qtil: 0.0.3

--- a/java/test/codeql-pack.lock.yml
+++ b/java/test/codeql-pack.lock.yml
@@ -1,28 +1,32 @@
 ---
 lockVersion: 1.0.0
 dependencies:
+  codeql/controlflow:
+    version: 2.0.13
   codeql/dataflow:
-    version: 1.1.6
+    version: 2.0.13
   codeql/java-all:
-    version: 4.2.1
+    version: 7.6.0
   codeql/mad:
-    version: 1.0.12
+    version: 1.0.29
+  codeql/quantum:
+    version: 0.0.7
   codeql/rangeanalysis:
-    version: 1.0.12
+    version: 1.0.29
   codeql/regex:
-    version: 1.0.12
+    version: 1.0.29
   codeql/ssa:
-    version: 1.0.12
+    version: 2.0.5
   codeql/threat-models:
-    version: 1.0.12
+    version: 1.0.29
   codeql/tutorial:
-    version: 1.0.12
+    version: 1.0.29
   codeql/typeflow:
-    version: 1.0.12
+    version: 1.0.29
   codeql/typetracking:
-    version: 1.0.12
+    version: 2.0.13
   codeql/util:
-    version: 1.0.12
+    version: 2.0.16
   codeql/xml:
-    version: 1.0.12
+    version: 1.0.29
 compiled: false

--- a/javascript/src/codeql-pack.lock.yml
+++ b/javascript/src/codeql-pack.lock.yml
@@ -1,26 +1,28 @@
 ---
 lockVersion: 1.0.0
 dependencies:
+  codeql/concepts:
+    version: 0.0.3
   codeql/dataflow:
-    version: 1.1.6
+    version: 2.0.13
   codeql/javascript-all:
-    version: 2.1.1
+    version: 2.6.9
   codeql/mad:
-    version: 1.0.12
+    version: 1.0.29
   codeql/regex:
-    version: 1.0.12
+    version: 1.0.29
   codeql/ssa:
-    version: 1.0.12
+    version: 2.0.5
   codeql/threat-models:
-    version: 1.0.12
+    version: 1.0.29
   codeql/tutorial:
-    version: 1.0.12
+    version: 1.0.29
   codeql/typetracking:
-    version: 1.0.12
+    version: 2.0.13
   codeql/util:
-    version: 1.0.12
+    version: 2.0.16
   codeql/xml:
-    version: 1.0.12
+    version: 1.0.29
   codeql/yaml:
-    version: 1.0.12
+    version: 1.0.29
 compiled: false

--- a/javascript/src/qlpack.yml
+++ b/javascript/src/qlpack.yml
@@ -1,8 +1,8 @@
 name: advanced-security/qtil-javascript
 library: true
 warnOnImplicitThis: false
-version: 0.0.2
+version: 0.0.3
 license: MIT
 dependencies:
   codeql/javascript-all: '>=0.0.1 <3.0.0'
-  advanced-security/qtil: 0.0.2
+  advanced-security/qtil: 0.0.3

--- a/javascript/test/codeql-pack.lock.yml
+++ b/javascript/test/codeql-pack.lock.yml
@@ -1,26 +1,28 @@
 ---
 lockVersion: 1.0.0
 dependencies:
+  codeql/concepts:
+    version: 0.0.3
   codeql/dataflow:
-    version: 1.1.6
+    version: 2.0.13
   codeql/javascript-all:
-    version: 2.1.1
+    version: 2.6.9
   codeql/mad:
-    version: 1.0.12
+    version: 1.0.29
   codeql/regex:
-    version: 1.0.12
+    version: 1.0.29
   codeql/ssa:
-    version: 1.0.12
+    version: 2.0.5
   codeql/threat-models:
-    version: 1.0.12
+    version: 1.0.29
   codeql/tutorial:
-    version: 1.0.12
+    version: 1.0.29
   codeql/typetracking:
-    version: 1.0.12
+    version: 2.0.13
   codeql/util:
-    version: 1.0.12
+    version: 2.0.16
   codeql/xml:
-    version: 1.0.12
+    version: 1.0.29
   codeql/yaml:
-    version: 1.0.12
+    version: 1.0.29
 compiled: false

--- a/python/src/codeql-pack.lock.yml
+++ b/python/src/codeql-pack.lock.yml
@@ -1,26 +1,28 @@
 ---
 lockVersion: 1.0.0
 dependencies:
+  codeql/concepts:
+    version: 0.0.3
   codeql/dataflow:
-    version: 1.1.6
+    version: 2.0.13
   codeql/mad:
-    version: 1.0.12
+    version: 1.0.29
   codeql/python-all:
-    version: 2.2.0
+    version: 4.0.13
   codeql/regex:
-    version: 1.0.12
+    version: 1.0.29
   codeql/ssa:
-    version: 1.0.12
+    version: 2.0.5
   codeql/threat-models:
-    version: 1.0.12
+    version: 1.0.29
   codeql/tutorial:
-    version: 1.0.12
+    version: 1.0.29
   codeql/typetracking:
-    version: 1.0.12
+    version: 2.0.13
   codeql/util:
-    version: 1.0.12
+    version: 2.0.16
   codeql/xml:
-    version: 1.0.12
+    version: 1.0.29
   codeql/yaml:
-    version: 1.0.12
+    version: 1.0.29
 compiled: false

--- a/python/src/qlpack.yml
+++ b/python/src/qlpack.yml
@@ -1,8 +1,8 @@
 name: advanced-security/qtil-python
 library: true
 warnOnImplicitThis: false
-version: 0.0.2
+version: 0.0.3
 license: MIT
 dependencies:
   codeql/python-all: '>=0.0.1 <5.0.0'
-  advanced-security/qtil: 0.0.2
+  advanced-security/qtil: 0.0.3

--- a/python/test/codeql-pack.lock.yml
+++ b/python/test/codeql-pack.lock.yml
@@ -1,26 +1,28 @@
 ---
 lockVersion: 1.0.0
 dependencies:
+  codeql/concepts:
+    version: 0.0.3
   codeql/dataflow:
-    version: 1.1.6
+    version: 2.0.13
   codeql/mad:
-    version: 1.0.12
+    version: 1.0.29
   codeql/python-all:
-    version: 2.2.0
+    version: 4.0.13
   codeql/regex:
-    version: 1.0.12
+    version: 1.0.29
   codeql/ssa:
-    version: 1.0.12
+    version: 2.0.5
   codeql/threat-models:
-    version: 1.0.12
+    version: 1.0.29
   codeql/tutorial:
-    version: 1.0.12
+    version: 1.0.29
   codeql/typetracking:
-    version: 1.0.12
+    version: 2.0.13
   codeql/util:
-    version: 1.0.12
+    version: 2.0.16
   codeql/xml:
-    version: 1.0.12
+    version: 1.0.29
   codeql/yaml:
-    version: 1.0.12
+    version: 1.0.29
 compiled: false

--- a/ruby/src/codeql-pack.lock.yml
+++ b/ruby/src/codeql-pack.lock.yml
@@ -1,22 +1,14 @@
 ---
 lockVersion: 1.0.0
 dependencies:
-  codeql/controlflow:
-    version: 1.0.12
-  codeql/dataflow:
-    version: 1.1.6
-  codeql/mad:
-    version: 1.0.12
   codeql/regex:
-    version: 1.0.12
+    version: 0.0.6
   codeql/ruby-all:
-    version: 2.0.4
+    version: 0.5.2
   codeql/ssa:
-    version: 1.0.12
+    version: 0.0.10
   codeql/tutorial:
-    version: 1.0.12
-  codeql/typetracking:
-    version: 1.0.12
+    version: 0.0.3
   codeql/util:
-    version: 1.0.12
+    version: 2.0.16
 compiled: false

--- a/ruby/src/qlpack.yml
+++ b/ruby/src/qlpack.yml
@@ -5,4 +5,4 @@ version: 0.0.2
 license: MIT
 dependencies:
   codeql/ruby-all: '>=0.0.1 <5.0.0'
-  advanced-security/qtil: 0.0.2
+  advanced-security/qtil: 0.0.3

--- a/ruby/test/codeql-pack.lock.yml
+++ b/ruby/test/codeql-pack.lock.yml
@@ -1,22 +1,14 @@
 ---
 lockVersion: 1.0.0
 dependencies:
-  codeql/controlflow:
-    version: 1.0.12
-  codeql/dataflow:
-    version: 1.1.6
-  codeql/mad:
-    version: 1.0.12
   codeql/regex:
-    version: 1.0.12
+    version: 0.0.6
   codeql/ruby-all:
-    version: 2.0.4
+    version: 0.5.2
   codeql/ssa:
-    version: 1.0.12
+    version: 0.0.10
   codeql/tutorial:
-    version: 1.0.12
-  codeql/typetracking:
-    version: 1.0.12
+    version: 0.0.3
   codeql/util:
-    version: 1.0.12
+    version: 2.0.16
 compiled: false

--- a/src/qlpack.yml
+++ b/src/qlpack.yml
@@ -1,7 +1,7 @@
 name: advanced-security/qtil
 library: true
 warnOnImplicitThis: false
-version: 0.0.2
+version: 0.0.3
 license: MIT
 dependencies:
-  codeql/util: ">=1.0.12 <3.0.0"
+  codeql/util: ">2.0.0 <3.0.0"

--- a/src/qtil/list/CondensedList.qll
+++ b/src/qtil/list/CondensedList.qll
@@ -59,10 +59,10 @@ module CondenseList<FiniteStringableType Item, Unary<Item>::Ret<int>::pred/1 get
    */
   module GroupBy<InfiniteType Division, Unary<Item>::Ret<Division>::pred/1 getDivision> {
     private newtype TList =
-      THead(Item l, Division t) { denseRank(t, l) = 1 } or
-      TCons(ListEntry prev, Item l) { prev.getDenseIndex() = denseRank(prev.getDivision(), l) - 1 }
+      THead(Item l, Division t) { l = denseRank(t, 1) } or
+      TCons(ListEntry prev, Item l) { l = denseRank(prev.getDivision(), prev.getDenseIndex() + 1) }
 
-    private module DenseRankConfig implements DenseRankInputSig2 {
+    private module DenseRankConfig implements DenseRankInputSig1 {
       class Ranked = Item;
 
       class C = Division;
@@ -70,7 +70,7 @@ module CondenseList<FiniteStringableType Item, Unary<Item>::Ret<int>::pred/1 get
       int getRank(Division d, Item i) { result = getSparseIndex(i) and d = getDivision(i) }
     }
 
-    private import DenseRank2<DenseRankConfig>
+    private import DenseRank1<DenseRankConfig>
 
     class ListEntry extends TList {
       Division getDivision() {
@@ -87,7 +87,7 @@ module CondenseList<FiniteStringableType Item, Unary<Item>::Ret<int>::pred/1 get
         this = TCons(_, result)
       }
 
-      int getDenseIndex() { result = denseRank(getDivision(), getItem()) }
+      int getDenseIndex() { getItem() = denseRank(getDivision(), result) }
 
       ListEntry getPrev() { this = TCons(result, _) }
 

--- a/swift/src/codeql-pack.lock.yml
+++ b/swift/src/codeql-pack.lock.yml
@@ -2,21 +2,21 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/controlflow:
-    version: 1.0.12
+    version: 2.0.7
   codeql/dataflow:
-    version: 1.1.6
+    version: 2.0.7
   codeql/mad:
-    version: 1.0.12
+    version: 1.0.23
   codeql/regex:
-    version: 1.0.12
+    version: 1.0.23
   codeql/ssa:
-    version: 1.0.12
+    version: 1.1.2
   codeql/swift-all:
-    version: 2.0.4
+    version: 4.3.0
   codeql/tutorial:
-    version: 1.0.12
+    version: 1.0.23
   codeql/typetracking:
-    version: 1.0.12
+    version: 2.0.7
   codeql/util:
-    version: 1.0.12
+    version: 2.0.10
 compiled: false

--- a/swift/src/qlpack.yml
+++ b/swift/src/qlpack.yml
@@ -1,8 +1,8 @@
 name: advanced-security/qtil-swift
 library: true
 warnOnImplicitThis: false
-version: 0.0.1
+version: 0.0.3
 license: MIT
 dependencies:
   codeql/swift-all: '>=0.0.1 <5.0.0'
-  advanced-security/qtil: 0.0.1
+  advanced-security/qtil: 0.0.3

--- a/swift/test/codeql-pack.lock.yml
+++ b/swift/test/codeql-pack.lock.yml
@@ -2,21 +2,21 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/controlflow:
-    version: 1.0.12
+    version: 2.0.7
   codeql/dataflow:
-    version: 1.1.6
+    version: 2.0.7
   codeql/mad:
-    version: 1.0.12
+    version: 1.0.23
   codeql/regex:
-    version: 1.0.12
+    version: 1.0.23
   codeql/ssa:
-    version: 1.0.12
+    version: 1.1.2
   codeql/swift-all:
-    version: 2.0.4
+    version: 4.3.0
   codeql/tutorial:
-    version: 1.0.12
+    version: 1.0.23
   codeql/typetracking:
-    version: 1.0.12
+    version: 2.0.7
   codeql/util:
-    version: 1.0.12
+    version: 2.0.10
 compiled: false

--- a/test/codeql-pack.lock.yml
+++ b/test/codeql-pack.lock.yml
@@ -2,23 +2,23 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/cpp-all:
-    version: 2.1.1
+    version: 4.0.3
   codeql/dataflow:
-    version: 1.1.6
+    version: 2.0.3
   codeql/mad:
-    version: 1.0.12
+    version: 1.0.19
   codeql/rangeanalysis:
-    version: 1.0.12
+    version: 1.0.19
   codeql/ssa:
-    version: 1.0.12
+    version: 1.0.19
   codeql/tutorial:
-    version: 1.0.12
+    version: 1.0.19
   codeql/typeflow:
-    version: 1.0.12
+    version: 1.0.19
   codeql/typetracking:
-    version: 1.0.12
+    version: 2.0.3
   codeql/util:
-    version: 1.0.12
+    version: 2.0.6
   codeql/xml:
-    version: 1.0.12
+    version: 1.0.19
 compiled: false

--- a/test/qlpack.yml
+++ b/test/qlpack.yml
@@ -5,5 +5,5 @@ version: 0.0.1
 license: MIT
 dependencies:
   advanced-security/qtil: "*"
-  codeql/cpp-all: "2.1.1"
+  codeql/cpp-all: 4.0.3
 extractor: cpp

--- a/test/qtil/list/CondensedListTest.ql
+++ b/test/qtil/list/CondensedListTest.ql
@@ -14,7 +14,7 @@ class TestFib2 extends Test, Case {
         x.getNext().getItem() = 3
       )
     then test.pass("Correct handling of fib 2")
-    else test.fail("Incorrect handling of fib 2)")
+    else test.fail("Incorrect handling of fib 2")
   }
 }
 


### PR DESCRIPTION
Previous publication didn't properly test modules with the latest codeql/util, thus missing a breaking change to `DenseRank` that affected some modules.

Publish a fix to this as 0.0.3 -- fixes the codeql/util constraint, and adapts modules to the new `DenseRank` API.